### PR TITLE
Create Juror

### DIFF
--- a/townsfolk/investigative/Juror
+++ b/townsfolk/investigative/Juror
@@ -1,0 +1,9 @@
+**Juror** | Townsfolk Investigative/Group
+__Basics__
+The Jurors have a secret channel where they can communicate among themselves securely. On alternate days, the Jury votes to arraign and investigate a player.
+If the Jury successfuly arraigns a non-town role, it is announced.
+__Details__
+The Juror is part of the Jury. After Day 0, on odd days, the cult can arraign a player, investigating them. 
+The Jury recieves the result of the investigation at the end of the day. If the result of the investigation shows a non-town role, the role is immediately announced publicly.
+The Jury is disbanded if there are 1 or more Jurors left; this means the Jury is active only if atleast two Jurors are alive. 
+Any member of the Jury, even if they lose their role, can still vote on who to arraign. The Jury is affected by weak disguises and obstructions.


### PR DESCRIPTION
This is a group/investigative role that I think can work well in big games. They're essentially bakers who can investigate every other day but have the risk of disbanding if enough of they die/become undead. I'm not sure if this falls in the group category or the investigative category.

_To note:_ The jury is affected by flute player obstructions as long as at-least one juror is enchanted. 
_To clarify:_ Only the **role** is announced publicly, not the player investigated.